### PR TITLE
Ergonomics improvements: `value` and `error`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,8 @@ const transform = _flow(
   _.map(Maybe.map(length)),
   // drop `Nothing` instances
   _.filter(Maybe.isJust),
-  // unwrap now that it's safe to do so
-  _.map(Maybe.unsafelyUnwrap),
+  // get value now that it's safe to do so (TS will not allow earlier)
+  _.map(maybe => maybe.value),
   // only keep the even numbers ('fish' => 4)
   _.filter(even),
   // multiply by three
@@ -342,8 +342,8 @@ const transform = _flow(
   maybeStrings => _.map(maybeStrings, maybeString => Maybe.map(length, maybeString)),
   // drop `Nothing` instances
   maybeLengths => _.filter(maybeLengths, Maybe.isJust),
-  // unwrap now that it's safe to do so
-  justLengths => _.map(justLengths, Maybe.unsafelyUnwrap),
+  // get value now that it's safe to do so (TS will not allow earlier)
+  justLengths => _.map(justLengths, maybe => maybe.value),
   // only keep the even numbers ('fish' => 4)
   lengths => _.filter(lengths, even),
   // multiply by three
@@ -817,8 +817,8 @@ In many cases, you can simple rename your imports and some of the function invoc
 
 - [ ] TODO: rest of the migration path from Folktale 2.0
 
-| Folktale               | True Myth          | Notes                                                                                                                                                          |
-|------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|
+|        Folktale        |     True Myth      |                                                                             Notes                                                                              |
+| ---------------------- | ------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Maybe`                | `Maybe `           |                                                                                                                                                                |
 | `Maybe.hasInstance`    | no equivalent      |                                                                                                                                                                |
 | `Maybe.empty`          | `Maybe.nothing`    |                                                                                                                                                                |
@@ -839,8 +839,8 @@ In many cases, you can simple rename your imports and some of the function invoc
 | `Nothing#type`         | no equivalent      |                                                                                                                                                                |
 | `Just#concat`          | no equivalent      |                                                                                                                                                                |
 | `Nothing#concat`       | no equivalent      |                                                                                                                                                                |
-| `Just#equals`          | no equivalent      | Consider using e.g. [`_.isEqual`] or [`R.equals`]                                                                                                              |
-| `Nothing#equals`       | no equivalent      | Consider using e.g. [`_.isEqual`] or [`R.equals`]                                                                                                              |
+| `Just#equals`          | `Just#equals`      | You can also use the static method `Maybe.equals`                                                                                                              |
+| `Nothing#equals`       | `Nothing#equals`   | You can also use the static method `Maybe.equals`                                                                                                              |
 | `Result`               | `Result`           |                                                                                                                                                                |
 | `Validation`           | no equivalent      | You can use `Result` instead: a `Validation<Success, Failure>` has identical semantics to `Result<T, E>`                                                       |
 
@@ -851,8 +851,8 @@ In many cases, you can simple rename your imports and some of the function invoc
 
 There are straightforward conversions from most Sanctuary functions to True Myth functions.
 
-| Sanctuary   | True Myth  | Notes |
-|-------------|------------|-------|
+|  Sanctuary  | True Myth  | Notes |
+| ----------- | ---------- | ----- |
 | `S.Either`  | `Result`   |       |
 | `Left`      | `Err`      |       |
 | `Right`     | `Ok`       |       |

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "bugs": {
     "url": "https://github.com/chriskrycho/true-myth/issues"
   },
-  "version": "1.2.0",
+  "version": "1.3.0",
   "main": "dist/commonjs/src/index.js",
   "module": "dist/modules/src/index.js",
   "types": "dist/types/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "scripts": {
     "clean": "rimraf dist",
     "doc": "./scripts/build-docs",
-    "precommit": "./scripts/build-docs && git add docs",
     "problems": "node ./scripts/problems.js",
     "preversion": "yarn run test && yarn run prepack",
     "prepack": "ember build -prod && cp ./src/flow/* ./dist/modules/src && cp ./src/flow/* ./dist/commonjs/src",
@@ -44,7 +43,6 @@
     "@types/jest": "^22.1.1",
     "ember-cli": "^2.18.2",
     "flow-bin": "^0.64.0",
-    "husky": "^0.14.3",
     "jest": "^22.1.4",
     "libkit": "^0.5.17",
     "prettier": "^1.10.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@
  */
 
 /** (keep typedoc from getting confused by the imports) */
-import Maybe from './maybe';
-import Result from './result';
-import Unit from './unit';
-
-export { Maybe, Result, Unit };
+export { default as Maybe } from './maybe';
+export { default as Result } from './result';
+export { default as Unit } from './unit';

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1,7 +1,7 @@
 /** [[include:doc/maybe.md]] */
 
 /** (keep typedoc from getting confused by the imports) */
-import Result, { err, isOk, ok } from './result';
+import Result, { err, ok } from './result';
 import { curry1, isVoid } from './utils';
 
 /**
@@ -18,7 +18,7 @@ export enum Variant {
 /** Simply defines the common shape for `Just` and `Nothing`. */
 export interface MaybeShape<T> {
   /** Distinguish between the `Just` and `Nothing` [variants](../enums/_maybe_.variant). */
-  variant: Variant;
+  readonly variant: Variant;
 
   /** Method variant for [`Maybe.isJust`](../modules/_maybe_.html#isjust) */
   isJust(this: Maybe<T>): this is Just<T>;
@@ -87,10 +87,32 @@ export interface MaybeShape<T> {
   @typeparam T The type wrapped in this `Just` variant of `Maybe`.
  */
 export class Just<T> implements MaybeShape<T> {
-  /** `Just` is always [`Variant.Just`](../enums/_maybe_.variant#just). */
-  variant = Variant.Just;
+  /**
+    Unwrap the contained value. A convenience method for functional idioms.
 
-  private value: T;
+    A common scenario where you might want to use this is in a pipeline of
+    functions:
+
+    ```ts
+    import Maybe, { Just } from 'true-myth/maybe';
+
+    function getLengths(maybeStrings: Array<Maybe<string>>): Array<number> {
+      return maybeStrings
+        .filter(Maybe.isJust)
+        .map(Just.unwrap)
+        .map(s => s.length);
+    }
+    ```
+   */
+  static unwrap<J>(theJust: Just<J>): J {
+    return theJust.value;
+  }
+
+  /** `Just` is always [`Variant.Just`](../enums/_maybe_.variant#just). */
+  readonly variant: Variant.Just = Variant.Just;
+
+  /** The wrapped value. */
+  readonly value: T;
 
   /**
     Create an instance of `Maybe.Just` with `new`.
@@ -130,12 +152,12 @@ export class Just<T> implements MaybeShape<T> {
 
   /** Method variant for [`Maybe.isJust`](../modules/_maybe_.html#isjust) */
   isJust(this: Maybe<T>): this is Just<T> {
-    return isJust(this);
+    return true;
   }
 
   /** Method variant for [`Maybe.isNothing`](../modules/_maybe_.html#isnothing) */
   isNothing(this: Maybe<T>): this is Nothing<T> {
-    return isNothing(this);
+    return false;
   }
 
   /** Method variant for [`Maybe.map`](../modules/_maybe_.html#map) */
@@ -239,7 +261,7 @@ export class Just<T> implements MaybeShape<T> {
  */
 export class Nothing<T> implements MaybeShape<T> {
   /** `Nothing` is always [`Variant.Nothing`](../enums/_maybe_.variant#nothing). */
-  variant = Variant.Nothing;
+  readonly variant: Variant.Nothing = Variant.Nothing;
 
   /**
     Create an instance of `Maybe.Nothing` with `new`.
@@ -272,12 +294,12 @@ export class Nothing<T> implements MaybeShape<T> {
 
   /** Method variant for [`Maybe.isJust`](../modules/_maybe_.html#isjust) */
   isJust(this: Maybe<T>): this is Just<T> {
-    return isJust(this);
+    return false;
   }
 
   /** Method variant for [`Maybe.isNothing`](../modules/_maybe_.html#isnothing) */
   isNothing(this: Maybe<T>): this is Nothing<T> {
-    return isNothing(this);
+    return true;
   }
 
   /** Method variant for [`Maybe.map`](../modules/_maybe_.html#map) */
@@ -506,7 +528,7 @@ export function map<T, U>(
   mapFn: (t: T) => U,
   maybe?: Maybe<T>
 ): Maybe<U> | ((maybe: Maybe<T>) => Maybe<U>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? just(mapFn(unwrap(m))) : nothing<U>());
+  const op = (m: Maybe<T>) => (m.isJust() ? just(mapFn(m.value)) : nothing<U>());
   return curry1(op, maybe);
 }
 
@@ -543,7 +565,7 @@ export function mapOr<T, U>(
   maybe?: Maybe<T>
 ): U | ((maybe: Maybe<T>) => U) | ((mapFn: (t: T) => U) => (maybe: Maybe<T>) => U) {
   function fullOp(fn: (t: T) => U, m: Maybe<T>) {
-    return isJust(m) ? fn(unwrap(m)) : orU;
+    return m.isJust() ? fn(m.value) : orU;
   }
 
   function partialOp(fn: (t: T) => U): (maybe: Maybe<T>) => U;
@@ -593,7 +615,7 @@ export function mapOrElse<T, U>(
   maybe?: Maybe<T>
 ): U | ((maybe: Maybe<T>) => U) | ((mapFn: (t: T) => U) => (maybe: Maybe<T>) => U) {
   function fullOp(fn: (t: T) => U, m: Maybe<T>) {
-    return isJust(m) ? fn(unwrap(m)) : orElseFn();
+    return m.isJust() ? fn(m.value) : orElseFn();
   }
 
   function partialOp(fn: (t: T) => U): (maybe: Maybe<T>) => U;
@@ -653,7 +675,7 @@ export function and<T, U>(
   andMaybe: Maybe<U>,
   maybe?: Maybe<T>
 ): Maybe<U> | ((maybe: Maybe<T>) => Maybe<U>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? andMaybe : (nothing() as Maybe<U>));
+  const op = (m: Maybe<T>) => (m.isJust() ? andMaybe : nothing<U>());
   return curry1(op, maybe);
 }
 
@@ -715,7 +737,7 @@ export function andThen<T, U>(
   thenFn: (t: T) => Maybe<U>,
   maybe?: Maybe<T>
 ): Maybe<U> | ((maybe: Maybe<T>) => Maybe<U>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? thenFn(unwrap(m)) : (nothing() as Maybe<U>));
+  const op = (m: Maybe<T>) => (m.isJust() ? thenFn(m.value) : nothing<U>());
   return maybe !== undefined ? op(maybe) : op;
 }
 
@@ -758,7 +780,7 @@ export function or<T>(
   defaultMaybe: Maybe<T>,
   maybe?: Maybe<T>
 ): Maybe<T> | ((maybe: Maybe<T>) => Maybe<T>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? m : defaultMaybe);
+  const op = (m: Maybe<T>) => (m.isJust() ? m : defaultMaybe);
   return maybe !== undefined ? op(maybe) : op;
 }
 
@@ -784,7 +806,7 @@ export function orElse<T>(
   elseFn: () => Maybe<T>,
   maybe?: Maybe<T>
 ): Maybe<T> | ((maybe: Maybe<T>) => Maybe<T>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? m : elseFn());
+  const op = (m: Maybe<T>) => (m.isJust() ? m : elseFn());
   return curry1(op, maybe);
 }
 
@@ -799,17 +821,15 @@ export function orElse<T>(
   @returns     The unwrapped value if the `Maybe` instance is `Just`.
   @throws      If the `maybe` is `Nothing`.
  */
-export const unsafelyUnwrap = <T>(maybe: Maybe<T>): T => maybe.unsafelyUnwrap();
+export function unsafelyUnwrap<T>(maybe: Maybe<T>): T {
+  return maybe.unsafelyUnwrap();
+}
 
 /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
 export const unsafelyGet = unsafelyUnwrap;
 
 /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
 export const unsafeGet = unsafelyUnwrap;
-
-// For internal use; but not exported because we want to emphasize that this is
-// a bad idea via the name.
-const unwrap = unsafelyUnwrap;
 
 /**
   Safely get the value out of a `Maybe`.
@@ -835,8 +855,8 @@ const unwrap = unsafelyUnwrap;
  */
 export function unwrapOr<T>(defaultValue: T, maybe: Maybe<T>): T;
 export function unwrapOr<T>(defaultValue: T): (maybe: Maybe<T>) => T;
-export function unwrapOr<T>(defaultValue: T, maybe?: Maybe<T>): T | ((maybe: Maybe<T>) => T) {
-  const op = (m: Maybe<T>) => (isJust(m) ? unwrap(m) : defaultValue);
+export function unwrapOr<T>(defaultValue: T, maybe?: Maybe<T>) {
+  const op = (m: Maybe<T>) => (m.isJust() ? m.value : defaultValue);
   return curry1(op, maybe);
 }
 
@@ -875,7 +895,7 @@ export const getOr = unwrapOr;
 export function unwrapOrElse<T>(orElseFn: () => T, maybe: Maybe<T>): T;
 export function unwrapOrElse<T>(orElseFn: () => T): (maybe: Maybe<T>) => T;
 export function unwrapOrElse<T>(orElseFn: () => T, maybe?: Maybe<T>): T | ((maybe: Maybe<T>) => T) {
-  const op = (m: Maybe<T>) => (isJust(m) ? unwrap(m) : orElseFn());
+  const op = (m: Maybe<T>) => (m.isJust() ? m.value : orElseFn());
   return curry1(op, maybe);
 }
 
@@ -900,7 +920,7 @@ export function toOkOrErr<T, E>(
   error: E,
   maybe?: Maybe<T>
 ): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? ok(unwrap(m)) : err(error)) as Result<T, E>;
+  const op = (m: Maybe<T>) => (m.isJust() ? ok<T, E>(m.value) : err<T, E>(error));
   return maybe !== undefined ? op(maybe) : op;
 }
 
@@ -922,7 +942,7 @@ export function toOkOrElseErr<T, E>(
   elseFn: () => E,
   maybe?: Maybe<T>
 ): Result<T, E> | ((maybe: Maybe<T>) => Result<T, E>) {
-  const op = (m: Maybe<T>) => (isJust(m) ? ok(unwrap(m)) : err(elseFn())) as Result<T, E>;
+  const op = (m: Maybe<T>) => (m.isJust() ? ok<T, E>(m.value) : err<T, E>(elseFn()));
   return curry1(op, maybe);
 }
 
@@ -939,8 +959,8 @@ export function toOkOrElseErr<T, E>(
   @param result The `Result` to construct a `Maybe` from.
   @returns      `Just` if `result` was `Ok` or `Nothing` if it was `Err`.
  */
-export function fromResult<T, E>(result: Result<T, E>): Maybe<T> {
-  return isOk(result) ? just(Result.unsafelyUnwrap(result)) : nothing();
+export function fromResult<T>(result: Result<T, any>): Maybe<T> {
+  return result.isOk() ? just(result.value) : nothing<T>();
 }
 
 /**
@@ -963,7 +983,7 @@ export function fromResult<T, E>(result: Result<T, E>): Maybe<T> {
   @returns     The string representation of the `Maybe`.
  */
 export function toString<T>(maybe: Maybe<T>): string {
-  const body = isJust(maybe) ? `(${unwrap(maybe).toString()})` : '';
+  const body = maybe.isJust() ? `(${maybe.value.toString()})` : '';
   return `${maybe.variant}${body}`;
 }
 
@@ -988,7 +1008,7 @@ export type Matcher<T, A> = {
   import Maybe from 'true-myth/maybe';
 
   const logValue = (mightBeANumber: Maybe<number>) => {
-    const valueToLog = Maybe.isJust(mightBeANumber)
+    const valueToLog = Maybe.mightBeANumber.isJust()
       ? Maybe.unsafelyUnwrap(mightBeANumber).toString()
       : 'Nothing to log.';
 
@@ -1057,13 +1077,13 @@ export function equals<T>(mb: Maybe<T>): (ma: Maybe<T>) => boolean;
 export function equals<T>(mb: Maybe<T>, ma?: Maybe<T>): boolean | ((a: Maybe<T>) => boolean) {
   return ma !== undefined
     ? ma.match({
-        Just: aVal => isJust(mb) && mb.unsafelyUnwrap() === aVal,
+        Just: aVal => mb.isJust() && mb.unsafelyUnwrap() === aVal,
         Nothing: () => isNothing(mb),
       })
     : (maybeA: Maybe<T>) =>
         maybeA.match({
           Nothing: () => isNothing(mb),
-          Just: aVal => isJust(mb) && mb.unsafelyUnwrap() === aVal,
+          Just: aVal => mb.isJust() && mb.unsafelyUnwrap() === aVal,
         });
 }
 
@@ -1253,699 +1273,39 @@ export function isInstance<T = any>(item: any): item is Maybe<T> {
 /** A value which may (`Just<T>`) or may not (`Nothing`) be present. */
 export type Maybe<T> = Just<T> | Nothing<T>;
 export const Maybe = {
-  /**
-    Discriminant for the `Just` and `Nothing` variants.
-
-    You can use the discriminant via the `variant` property of `Maybe` instances
-    if you need to match explicitly on it.
-  */
   Variant,
-  /**
-    A `Just` instance is the *present* variant instance of the
-    [`Maybe`](../modules/_maybe_.html#maybe) type, representing the presence of a
-    value which may be absent. For a full discussion, see [the module
-    docs](../modules/_maybe_.html).
-
-    @typeparam T The type wrapped in this `Just` variant of `Maybe`.
-  */
   Just,
-  /**
-    A `Nothing` instance is the *absent* variant instance of the
-    [`Maybe`](../modules/_maybe_.html#maybe) type, representing the presence of a
-    value which may be absent. For a full discussion, see [the module
-    docs](../modules/_maybe_.html).
-
-    @typeparam T The type which would be wrapped in a `Just` variant of `Maybe`.
-  */
   Nothing,
-  /**
-    Is this result a `Just` instance?
-
-    @typeparam T The type of the wrapped value.
-    @param maybe The `Maybe` instance to check.
-    @returns     `true` if `maybe` is `Just`, `false` otherwise. In TypeScript,
-                also narrows the type from `Maybe<T>` to `Just<T>`.
-  */
   isJust,
-  /**
-    Is this result a `Nothing` instance?
-
-    @typeparam T The type of the wrapped value.
-    @param maybe The `Maybe` instance to check.
-    @returns     `true` if `maybe` is `nothing`, `false` otherwise. In TypeScript,
-                also narrows the type from `Maybe<T>` to `Nothing<T>`.
-  */
   isNothing,
-  /**
-    Create an instance of `Maybe.Just`.
-
-    `null` and `undefined` are allowed by the type signature so that the
-    function may `throw` on those rather than constructing a type like
-    `Maybe<undefined>`.
-
-    @typeparam T The type of the item contained in the `Maybe`.
-    @param value The value to wrap in a `Maybe.Just`.
-    @returns     An instance of `Maybe.Just<T>`.
-    @throws      If you pass `null` or `undefined`.
-  */
   just,
-  /**
-    Create an instance of `Maybe.Nothing`.
-
-    If you want to create an instance with a specific type, e.g. for use in a
-    function which expects a `Maybe<T>` where the `<T>` is known but you have no
-    value to give it, you can use a type parameter:
-
-    ```ts
-    const notString = Maybe.nothing<string>();
-    ```
-
-    @typeparam T The type of the item contained in the `Maybe`.
-    @returns     An instance of `Maybe.Nothing<T>`.
-  */
   nothing,
-  /**
-    Create a `Maybe` from any value.
-
-    To specify that the result should be interpreted as a specific type, you may
-    invoke `Maybe.of` with an explicit type parameter:
-
-    ```ts
-    const foo = Maybe.of<string>(null);
-    ```
-
-    This is usually only important in two cases:
-
-    1.  If you are intentionally constructing a `Nothing` from a known `null` or
-        undefined value *which is untyped*.
-    2.  If you are specifying that the type is more general than the value passed
-        (since TypeScript can define types as literals).
-
-    @typeparam T The type of the item contained in the `Maybe`.
-    @param value The value to wrap in a `Maybe`. If it is `undefined` or `null`,
-                the result will be `Nothing`; otherwise it will be the type of
-                the value passed.
-  */
   of,
-  /** Alias for [`of`](#of), primarily for compatibility with Folktale. */
   fromNullable,
-  /**
-    Map over a `Maybe` instance: apply the function to the wrapped value if the
-    instance is `Just`, and return `Nothing` if the instance is `Nothing`.
-
-    `Maybe.map` works a lot like `Array.prototype.map`: `Maybe` and `Array` are
-    both *containers* for other things. If you have no items in an array of
-    numbers named `foo` and call `foo.map(x => x + 1)`, you'll still just have an
-    array with nothing in it. But if you have any items in the array (`[2, 3]`),
-    and you call `foo.map(x => x + 1)` on it, you'll get a new array with each of
-    those items inside the array "container" transformed (`[3, 4]`).
-
-    That's exactly what's happening with `Maybe.map`. If the container is *empty*
-    – the `Nothing` variant – you just get back an empty container. If the
-    container has something in it – the `Just` variant – you get back a container
-    with the item inside transformed.
-
-    (So... why not just use an array? The biggest reason is that an array can be
-    any length. With a `Maybe`, we're capturing the idea of "something or
-    nothing" rather than "0 to n" items. And this lets us implement a whole set
-    of *other* interfaces, like those in this module.)
-
-    #### Examples
-
-    ```ts
-    const length = (s: string) => s.length;
-
-    const justAString = Maybe.just('string');
-    const justTheStringLength = map(length, justAString);
-    console.log(justTheStringLength.toString()); // Just(6)
-
-    const notAString = Maybe.nothing<string>();
-    const notAStringLength = map(length, notAString);
-    console.log(notAStringLength.toString()); // "Nothing"
-    ```
-
-    @typeparam T The type of the wrapped value.
-    @typeparam U The type of the wrapped value of the returned `Maybe`.
-    @param mapFn The function to apply the value to if `Maybe` is `Just`.
-    @param maybe The `Maybe` instance to map over.
-    @returns     A new `Maybe` with the result of applying `mapFn` to the value
-                in a `Just`, or `Nothing` if `maybe` is `Nothing`.
-  */
   map,
-  /**
-    Map over a `Maybe` instance and get out the value if `maybe` is a `Just`, or
-    return a default value if `maybe` is a `Nothing`.
-
-    #### Examples
-
-    ```ts
-    const length = (s: string) => s.length;
-
-    const justAString = Maybe.just('string');
-    const theStringLength = mapOr(0, length, justAString);
-    console.log(theStringLength); // 6
-
-    const notAString = Maybe.nothing<string>();
-    const notAStringLength = mapOr(0, length, notAString)
-    console.log(notAStringLength); // 0
-    ```
-
-    @typeparam T The type of the wrapped value.
-    @typeparam U The type of the wrapped value of the returned `Maybe`.
-    @param orU   The default value to use if `maybe` is `Nothing`
-    @param mapFn The function to apply the value to if `Maybe` is `Just`
-    @param maybe The `Maybe` instance to map over.
-  */
   mapOr,
-  /**
-    Map over a `Maybe` instance and get out the value if `maybe` is a `Just`,
-    or use a function to construct a default value if `maybe` is `Nothing`.
-
-    #### Examples
-
-    ```ts
-    const length = (s: string) => s.length;
-    const getDefault = () => 0;
-
-    const justAString = Maybe.just('string');
-    const theStringLength = mapOrElse(getDefault, length, justAString);
-    console.log(theStringLength); // 6
-
-    const notAString = Maybe.nothing<string>();
-    const notAStringLength = mapOrElse(getDefault, length, notAString)
-    console.log(notAStringLength); // 0
-    ```
-
-    @typeparam T    The type of the wrapped value.
-    @typeparam U    The type of the wrapped value of the returned `Maybe`.
-    @param orElseFn The function to apply if `maybe` is `Nothing`.
-    @param mapFn    The function to apply to the wrapped value if `maybe` is `Just`
-    @param maybe    The `Maybe` instance to map over.
-  */
   mapOrElse,
-  /**
-    You can think of this like a short-circuiting logical "and" operation on a
-    `Maybe` type. If `maybe` is `Just`, then the result is the `andMaybe`. If
-    `maybe` is `Nothing`, the result is `Nothing`.
-
-    This is useful when you have another `Maybe` value you want to provide if and
-    *only if* you have a `Just` – that is, when you need to make sure that if you
-    `Nothing`, whatever else you're handing a `Maybe` to *also* gets a `Nothing`.
-
-    Notice that, unlike in [`map`](#map) or its variants, the original `maybe` is
-    not involved in constructing the new `Maybe`.
-
-    #### Examples
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    const justA = Maybe.just('A');
-    const justB = Maybe.just('B');
-    const nothing: Maybe<number> = nothing();
-
-    console.log(Maybe.and(justB, justA).toString());  // Just(B)
-    console.log(Maybe.and(justB, nothing).toString());  // Nothing
-    console.log(Maybe.and(nothing, justA).toString());  // Nothing
-    console.log(Maybe.and(nothing, nothing).toString());  // Nothing
-    ```
-
-    @typeparam T    The type of the initial wrapped value.
-    @typeparam U    The type of the wrapped value of the returned `Maybe`.
-    @param andMaybe The `Maybe` instance to return if `maybe` is `Just`
-    @param maybe    The `Maybe` instance to check.
-    @return         `Nothing` if the original `maybe` is `Nothing`, or `andMaybe`
-                    if the original `maybe` is `Just`.
-  */
   and,
-  /**
-    Apply a function to the wrapped value if `Just` and return a new `Just`
-    containing the resulting value; or return `Nothing` if `Nothing`.
-
-    This differs from `map` in that `thenFn` returns another `Maybe`. You can use
-    `andThen` to combine two functions which *both* create a `Maybe` from an
-    unwrapped type.
-
-    You may find the `.then` method on an ES6 `Promise` helpful for b:
-    if you have a `Promise`, you can pass its `then` method a callback which
-    returns another `Promise`, and the result will not be a *nested* promise, but
-    a single `Promise`. The difference is that `Promise#then` unwraps *all*
-    layers to only ever return a single `Promise` value, whereas `Maybe.andThen`
-    will not unwrap nested `Maybe`s.
-
-    This is also commonly known as (and therefore aliased as) [`flatMap`] or
-    [`chain`]. It is sometimes also known as `bind`, but *not* aliased as such
-    because [`bind` already means something in JavaScript][bind].
-
-    [`flatMap`]: #flatmap
-    [`chain`]: #chain
-    [bind]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-
-    #### Example
-
-    (This is a somewhat contrived example, but it serves to show the way the
-    function behaves.)
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    // string -> Maybe<number>
-    const toMaybeLength = (s: string): Maybe<number> => Maybe.of(s.length);
-
-    // Maybe<string>
-    const aMaybeString = Maybe.of('Hello, there!');
-
-    // Maybe<number>
-    const resultingLength = Maybe.andThen(toMaybeLength, aMaybeString);
-    console.log(Maybe.toString(resultingLength)); // 13
-    ```
-
-    Note that the result is not `(Just(13))`, but `13`!
-
-    @typeparam T  The type of the wrapped value.
-    @typeparam T  The type of the wrapped value in the resulting `Maybe`.
-    @param thenFn The function to apply to the wrapped `T` if `maybe` is `Just`.
-    @param maybe  The `Maybe` to evaluate and possibly apply a function to the
-                  contents of.
-    @returns      The result of the `thenFn` (a new `Maybe`) if `maybe` is a
-                  `Just`, otherwise `Nothing` if `maybe` is a `Nothing`.
-  */
   andThen,
-  /** Alias for [`andThen`](#andthen). */
   chain,
-  /** Alias for [`andThen`](#andthen). */
   flatMap,
-  /**
-    Provide a fallback for a given `Maybe`. Behaves like a logical `or`: if the
-    `maybe` value is a `Just`, returns that `maybe`; otherwise, returns the
-    `defaultMaybe` value.
-
-    This is useful when you want to make sure that something which takes a
-    `Maybe` always ends up getting a `Just` variant, by supplying a default value
-    for the case that you currently have a nothing.
-
-    ```ts
-    import Maybe from 'true-utils/maybe';
-
-    const justA = Maybe.just("a");
-    const justB = Maybe.just("b");
-    const aNothing: Maybe<string> = nothing();
-
-    console.log(Maybe.or(justB, justA).toString());  // Just(A)
-    console.log(Maybe.or(aNothing, justA).toString());  // Just(A)
-    console.log(Maybe.or(justB, aNothing).toString());  // Just(B)
-    console.log(Maybe.or(aNothing, aNothing).toString());  // Nothing
-    ```
-
-    @typeparam T        The type of the wrapped value.
-    @param defaultMaybe The `Maybe` to use if `maybe` is a `Nothing`.
-    @param maybe        The `Maybe` instance to evaluate.
-    @returns            `maybe` if it is a `Just`, otherwise `defaultMaybe`.
-  */
   or,
-  /**
-    Like `or`, but using a function to construct the alternative `Maybe`.
-
-    Sometimes you need to perform an operation using other data in the
-    environment to construct the fallback value. In these situations, you can
-    pass a function (which may be a closure) as the `elseFn` to generate the
-    fallback `Maybe<T>`.
-
-    Useful for transforming empty scenarios based on values in context.
-
-    @typeparam T  The type of the wrapped value.
-    @param elseFn The function to apply if `maybe` is `Nothing`
-    @param maybe  The `maybe` to use if it is `Just`.
-    @returns      The `maybe` if it is `Just`, or the `Maybe` returned by
-                  `elseFn` if the `maybe` is `Nothing`.
-  */
   orElse,
-  /**
-    Get the value out of the `Maybe`.
-
-    Returns the content of a `Just`, but **throws if the `Maybe` is `Nothing`**.
-    Prefer to use [`unwrapOr`](#unwrapor) or [`unwrapOrElse`](#unwraporelse).
-
-    @typeparam T The type of the wrapped value.
-    @param maybe The value to unwrap
-    @returns     The unwrapped value if the `Maybe` instance is `Just`.
-    @throws      If the `maybe` is `Nothing`.
-  */
   unsafelyUnwrap,
-  /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
   unsafelyGet,
-  /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
   unsafeGet,
-  /**
-    Safely get the value out of a `Maybe`.
-
-    Returns the content of a `Just` or `defaultValue` if `Nothing`. This is the
-    recommended way to get a value out of a `Maybe` most of the time.
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    const notAString = Maybe.nothing<string>();
-    const isAString = Maybe.just('look ma! some characters!');
-
-    console.log(Maybe.unwrapOr('<empty>', notAString));  // "<empty>"
-    console.log(Maybe.unwrapOr('<empty>', isAString));  // "look ma! some characters!"
-    ```
-
-    @typeparam T        The type of the wrapped value.
-    @param defaultValue The value to return if `maybe` is a `Nothing`.
-    @param maybe        The `Maybe` instance to unwrap if it is a `Just`.
-    @returns            The content of `maybe` if it is a `Just`, otherwise
-                        `defaultValue`.
-  */
   unwrapOr,
-  /** Alias for [`unwrapOr`](#unwrapor) */
   getOr,
-  /**
-    Safely get the value out of a [`Maybe`](#maybe) by returning the wrapped
-    value if it is `Just`, or by applying `orElseFn` if it is `Nothing`.
-
-    This is useful when you need to *generate* a value (e.g. by using current
-    values in the environment – whether preloaded or by local closure) instead of
-    having a single default value available (as in [`unwrapOr`](#unwrapor)).
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    // You can imagine that someOtherValue might be dynamic.
-    const someOtherValue = 99;
-    const handleNothing = () => someOtherValue;
-
-    const aJust = Maybe.just(42);
-    console.log(Maybe.unwrapOrElse(handleNothing, aJust));  // 42
-
-    const aNothing = nothing<number>();
-    console.log(Maybe.unwrapOrElse(handleNothing, aNothing)); // 99
-    ```
-
-    @typeparam T  The wrapped value.
-    @param orElseFn A function used to generate a valid value if `maybe` is a
-                    `Nothing`.
-    @param maybe    The `Maybe` instance to unwrap if it is a `Just`
-    @returns        Either the content of `maybe` or the value returned from
-                    `orElseFn`.
-  */
   unwrapOrElse,
-  /** Alias for [`unwrapOrElse`](#unwraporelse) */
   getOrElse,
-  /**
-    Transform the [`Maybe`](#maybe) into a
-    [`Result`](../modules/_result_.html#result), using the wrapped value as the
-    `Ok` value if `Just`; otherwise using the supplied `error` value for `Err`.
-
-    @typeparam T  The wrapped value.
-    @typeparam E  The error type to in the `Result`.
-    @param error The error value to use if the `Maybe` is `Nothing`.
-    @param maybe The `Maybe` instance to convert.
-    @returns     A `Result` containing the value wrapped in `maybe` in an `Ok`,
-                or `error` in an `Err`.
-  */
   toOkOrErr,
-  /**
-    Transform the [`Maybe`](#maybe) into a
-    [`Result`](../modules/_result_.html#result), using the wrapped value as the
-    `Ok` value if `Just`; otherwise using `elseFn` to generate `Err`.
-
-    @typeparam T  The wrapped value.
-    @typeparam E  The error type to in the `Result`.
-    @param elseFn The function which generates an error of type `E`.
-    @param maybe  The `Maybe` instance to convert.
-    @returns     A `Result` containing the value wrapped in `maybe` in an `Ok`,
-                or the value generated by `elseFn` in an `Err`.
-  */
   toOkOrElseErr,
-  /**
-    Construct a `Maybe<T>` from a `Result<T, E>`.
-
-    If the `Result` is an `Ok`, wrap its value in `Just`. If the `Result` is an
-    `Err`, throw away the wrapped `E` and transform to a `Nothing`.
-
-    @typeparam T  The type of the value wrapped in a `Result.Ok` and in the `Just`
-                  of the resulting `Maybe`.
-    @typeparam E  The type of the value wrapped in a `Result.Err`; thrown away in
-                  the resulting `Maybe`.
-    @param result The `Result` to construct a `Maybe` from.
-    @returns      `Just` if `result` was `Ok` or `Nothing` if it was `Err`.
-  */
   fromResult,
-  /**
-    Create a `String` representation of a `Maybe` instance.
-
-    A `Just` instance will be printed as `Just(<representation of the value>)`,
-    where the representation of the value is simply the value's own `toString`
-    representation. For example:
-
-    | call                                   | output                  |
-    |----------------------------------------|-------------------------|
-    | `toString(Maybe.of(42))`               | `Just(42)`              |
-    | `toString(Maybe.of([1, 2, 3]))`        | `Just(1,2,3)`           |
-    | `toString(Maybe.of({ an: 'object' }))` | `Just([object Object])` |
-    | `toString(Maybe.nothing())`            | `Nothing`               |
-
-    @typeparam T The type of the wrapped value; its own `.toString` will be used
-                to print the interior contents of the `Just` variant.
-    @param maybe The value to convert to a string.
-    @returns     The string representation of the `Maybe`.
-  */
   toString,
-  /**
-    Performs the same basic functionality as `getOrElse`, but instead of simply
-    unwrapping the value if it is `Just` and applying a value to generate the same
-    default type if it is `Nothing`, lets you supply functions which may transform
-    the wrapped type if it is `Just` or get a default value for `Nothing`.
-
-    This is kind of like a poor man's version of pattern matching, which
-    JavaScript currently lacks.
-
-    Instead of code like this:
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    const logValue = (mightBeANumber: Maybe<number>) => {
-      const valueToLog = Maybe.isJust(mightBeANumber)
-        ? Maybe.unsafelyUnwrap(mightBeANumber).toString()
-        : 'Nothing to log.';
-
-      console.log(valueToLog);
-    };
-    ```
-
-    ...we can write code like this:
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-
-    const logValue = (mightBeANumber: Maybe<number>) => {
-      const value = Maybe.match(
-        {
-          Just: n => n.toString(),
-          Nothing: () => 'Nothing to log.',
-        },
-        mightBeANumber
-      );
-
-      console.log(value);
-    };
-    ```
-
-    This is slightly longer to write, but clearer: the more complex the resulting
-    expression, the hairer it is to understand the ternary. Thus, this is
-    especially convenient for times when there is a complex result, e.g. when
-    rendering part of a React component inline in JSX/TSX.
-
-    @param matcher A lightweight object defining what to do in the case of each
-                  variant.
-    @param maybe   The `maybe` instance to check.
-  */
   match,
-  /** Alias for [`match`](#match) */
   cata,
-  /**
-    Allows quick triple-equal equality check between the values inside two
-    `maybe`s without having to unwrap them first.
-
-    ```ts
-    const a = Maybe.of(3);
-    const b = Maybe.of(3);
-    const c = Maybe.of(null);
-    const d = Maybe.nothing();
-
-    Maybe.equals(a, b); // true
-    Maybe.equals(a, c); // false
-    Maybe.equals(c, d); // true
-    ```
-
-    @param mb A `maybe` to compare to.
-    @param ma A `maybe` instance to check.
-  */
   equals,
-  /**
-    Allows you to *apply* (thus `ap`) a value to a function without having to
-    take either out of the context of their `Maybe`s. This does mean that the
-    transforming function is itself within a `Maybe`, which can be hard to grok
-    at first but lets you do some very elegant things. For example, `ap` allows
-    you to this:
-
-    ```ts
-    import { just, nothing } from 'true-myth/maybe';
-
-    const one = just(1);
-    const five = just(5);
-    const none = nothing();
-
-    const add = (a: number) => (b: number) => a + b;
-    const maybeAdd = just(add);
-
-    maybeAdd.ap(one).ap(five); // Just(6)
-    maybeAdd.ap(one).ap(none); // Nothing
-    maybeAdd.ap(none).ap(five) // Nothing
-    ```
-
-    Without `Maybe.ap`, you'd need to do something like a nested `Maybe.match`:
-
-    ```ts
-    import { just, nothing } from 'true-myth/maybe';
-
-    const one = just(1);
-    const five = just(5);
-    const none = nothing();
-
-    one.match({
-      Just: n => five.match({
-        Just: o => just(n + o),
-        Nothing: () => nothing(),
-      }),
-      Nothing: ()  => nothing(),
-    }); // Just(6)
-
-    one.match({
-      Just: n => none.match({
-        Just: o => just(n + o),
-        Nothing: () => nothing(),
-      }),
-      Nothing: ()  => nothing(),
-    }); // Nothing
-
-    none.match({
-      Just: n => five.match({
-        Just: o => just(n + o),
-        Nothing: () => nothing(),
-      }),
-      Nothing: ()  => nothing(),
-    }); // Nothing
-    ```
-
-    And this kind of thing comes up quite often once you're using `Maybe` to
-    handle optionality throughout your application.
-
-    For another example, imagine you need to compare the equality of two
-    ImmutableJS data structures, where a `===` comparison won't work. With `ap`,
-    that's as simple as this:
-
-    ```ts
-    import Maybe from 'true-myth/maybe';
-    import Immutable from 'immutable';
-    import { curry } from 'lodash'
-
-    const is = curry(Immutable.is);
-
-    const x = Maybe.of(Immutable.Set.of(1, 2, 3));
-    const y = Maybe.of(Immutable.Set.of(2, 3, 4));
-
-    Maybe.of(is).ap(x).ap(y); // Just(false)
-    ```
-
-    Without `ap`, we're back to that gnarly nested `match`:
-
-    ```ts
-    * import Maybe, { just, nothing } from 'true-myth/maybe';
-    import Immutable from 'immutable';
-    import { curry } from 'lodash'
-
-    const is = curry(Immutable.is);
-
-    const x = Maybe.of(Immutable.Set.of(1, 2, 3));
-    const y = Maybe.of(Immutable.Set.of(2, 3, 4));
-
-    x.match({
-      Just: iX => y.match({
-        Just: iY => Maybe.just(Immutable.is(iX, iY)),
-        Nothing: () => Maybe.nothing(),
-      })
-      Nothing: () => Maybe.nothing(),
-    }); // Just(false)
-    ```
-
-    In summary: anywhere you have two `Maybe` instances and need to perform an
-    operation that uses both of them, `ap` is your friend.
-
-    Two things to note, both regarding *currying*:
-
-    1.  All functions passed to `ap` must be curried. That is, they must be of the
-        form (for add) `(a: number) => (b: number) => a + b`, *not* the more usual
-        `(a: number, b: number) => a + b` you see in JavaScript more generally.
-
-        For convenience, you may want to look at Lodash's `_.curry` or Ramda's
-        `R.curry`, which allow you to create curried versions of functions
-        whenever you want:
-
-        ```
-        import Maybe from 'true-myth/maybe';
-        import { curry } from 'lodash';
-
-        const normalAdd = (a: number, b: number) => a + b;
-        const curriedAdd = curry(normalAdd); // (a: number) => (b: number) => a + b;
-
-        Maybe.of(curriedAdd).ap(Maybe.of(1)).ap(Maybe.of(5)); // Just(6)
-        ```
-
-    2.  You will need to call `ap` as many times as there are arguments to the
-        function you're dealing with. So in the case of `add`, which has the
-        "arity" (function argument count) of 2 (`a` and `b`), you'll need to call
-        `ap` twice: once for `a`, and once for `b`. To see why, let's look at what
-        the result in each phase is:
-
-        ```ts
-        const add = (a: number) => (b: number) => a + b;
-
-        const maybeAdd = Maybe.of(add); // Just((a: number) => (b: number) => a + b)
-        const maybeAdd1 = maybeAdd.ap(Maybe.of(1)); // Just((b: number) => 1 + b)
-        const final = maybeAdd1.ap(Maybe.of(3)); // Just(4)
-        ```
-
-        So for `toString`, which just takes a single argument, you would only need
-        to call `ap` once.
-
-        ```ts
-        const toStr = (v: { toString(): string }) => v.toString();
-        Maybe.of(toStr).ap(12); // Just("12")
-        ```
-
-    One other scenario which doesn't come up *quite* as often but is conceivable
-    is where you have something that may or may not actually construct a function
-    for handling a specific `Maybe` scenario. In that case, you can wrap the
-    possibly-present in `ap` and then wrap the values to apply to the function to
-    in `Maybe` themselves.
-
-    **Aside:** `ap` is not named `apply` because of the overlap with JavaScript's
-    existing [`apply`] function – and although strictly speaking, there isn't any
-    direct overlap (`Maybe.apply` and `Function.prototype.apply` don't intersect
-    at all) it's useful to have a different name to avoid implying that they're
-    the same.
-
-    [`apply`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
-
-    @param maybeFn maybe a function from T to U
-    @param maybe maybe a T to apply to `fn`
-  */
   ap,
-
   isInstance,
 };
 

--- a/src/result.ts
+++ b/src/result.ts
@@ -22,7 +22,7 @@ export enum Variant {
 /** Simply defines the common shape for `Ok` and `Err`. */
 export interface ResultShape<T, E> {
   /** Distinguish between the `Ok` and `Err` variants. */
-  variant: Variant;
+  readonly variant: Variant;
 
   /** Method variant for [`Result.isOk`](../modules/_result_.html#isok) */
   isOk(this: Result<T, E>): this is Ok<T, E>;
@@ -98,10 +98,32 @@ export interface ResultShape<T, E> {
   @typeparam E The type which would be wrapped in an `Err` variant of `Result`.
  */
 export class Ok<T, E> implements ResultShape<T, E> {
-  /** `Ok` is always [`Variant.Ok`](../enums/_result_.variant#ok). */
-  variant = Variant.Ok;
+  /**
+    Unwrap the contained value. A convenience method for functional idioms.
 
-  private value: T;
+    A common scenario where you might want to use this is in a pipeline of
+    functions:
+
+    ```ts
+    import Result, { Ok } from 'true-myth/result';
+
+    function getLengths(results: Array<Result<string, string>>): Array<number> {
+      return results
+        .filter(Result.isOk)
+        .map(Ok.unwrap)
+        .map(s => s.length);
+    }
+    ```
+   */
+  static unwrap<O>(theOk: Ok<O, any>): O {
+    return theOk.value;
+  }
+
+  /** `Ok` is always [`Variant.Ok`](../enums/_result_.variant#ok). */
+  readonly variant: Variant.Ok = Variant.Ok;
+
+  /** The wrapped value. */
+  readonly value: T;
 
   /**
     Create an instance of `Result.Ok` with `new`.
@@ -147,12 +169,12 @@ export class Ok<T, E> implements ResultShape<T, E> {
 
   /** Method variant for [`Result.isOk`](../modules/_result_.html#isok) */
   isOk(this: Result<T, E>): this is Ok<T, E> {
-    return isOk(this);
+    return true;
   }
 
   /** Method variant for [`Result.isErr`](../modules/_result_.html#iserr) */
   isErr(this: Result<T, E>): this is Err<T, E> {
-    return isErr(this);
+    return false;
   }
 
   /** Method variant for [`Result.map`](../modules/_result_.html#map) */
@@ -261,10 +283,32 @@ export class Ok<T, E> implements ResultShape<T, E> {
   @typeparam E The type wrapped in this `Err` variant of `Result`.
   */
 export class Err<T, E> implements ResultShape<T, E> {
-  /** `Err` is always [`Variant.Err`](../enums/_result_.variant#err). */
-  variant = Variant.Err;
+  /**
+    Unwrap the contained error . A convenience method for functional idioms.
 
-  private error: E;
+    A common scenario where you might want to use this is in a pipeline of
+    functions:
+
+    ```ts
+    import Result, { Ok } from 'true-myth/result';
+
+    function getMessages(results: Array<Result<string, Error>>): Array<number> {
+      return maybeStrings
+        .filter(Result.isErr)
+        .map(Err.unwrapErr)
+        .map(e => e.message);
+    }
+    ```
+   */
+  static unwrapErr<F>(theErr: Err<F, any>): F {
+    return theErr.error;
+  }
+
+  /** `Err` is always [`Variant.Err`](../enums/_result_.variant#err). */
+  readonly variant: Variant.Err = Variant.Err;
+
+  /** The wrapped error value. */
+  readonly error: E;
 
   /**
     Create an instance of `Result.Err` with `new`.
@@ -310,12 +354,12 @@ export class Err<T, E> implements ResultShape<T, E> {
 
   /** Method variant for [`Result.isOk`](../modules/_result_.html#isok) */
   isOk(this: Result<T, E>): this is Ok<T, E> {
-    return isOk(this);
+    return false;
   }
 
   /** Method variant for [`Result.isErr`](../modules/_result_.html#iserr) */
   isErr(this: Result<T, E>): this is Err<T, E> {
-    return isErr(this);
+    return true;
   }
 
   /** Method variant for [`Result.map`](../modules/_result_.html#map) */
@@ -419,16 +463,18 @@ export class Err<T, E> implements ResultShape<T, E> {
 
   In TypeScript, narrows the type from `Result<T, E>` to `Ok<T, E>`.
  */
-export const isOk = <T, E>(result: Result<T, E>): result is Ok<T, E> =>
-  result.variant === Variant.Ok;
+export function isOk<T, E>(result: Result<T, E>): result is Ok<T, E> {
+  return result.variant === Variant.Ok;
+}
 
 /**
   Is this `Result` an `Err` instance?
 
   In TypeScript, narrows the type from `Result<T, E>` to `Err<T, E>`.
  */
-export const isErr = <T, E>(result: Result<T, E>): result is Err<T, E> =>
-  result.variant === Variant.Err;
+export function isErr<T, E>(result: Result<T, E>): result is Err<T, E> {
+  return result.variant === Variant.Err;
+}
 
 /**
   Create an instance of `Result.Ok`.
@@ -475,7 +521,6 @@ export const isErr = <T, E>(result: Result<T, E>): result is Err<T, E> =>
 
   @typeparam T The type of the item contained in the `Result`.
   @param value The value to wrap in a `Result.Ok`.
-  @throws      If you pass `null` or `undefined`.
  */
 export function ok<T, E>(): Result<Unit, E>;
 export function ok<T, E>(value: T): Result<T, E>;
@@ -530,6 +575,7 @@ export const of = ok;
   ```
 
   @typeparam T The type of the item contained in the `Result`.
+  @param E The error value to wrap in a `Result.Err`.
  */
 export function err<T, E>(): Result<T, Unit>;
 export function err<T, E>(error: E): Result<T, E>;
@@ -595,7 +641,7 @@ export function map<T, U, E>(
   mapFn: (t: T) => U,
   result?: Result<T, E>
 ): Result<U, E> | ((result: Result<T, E>) => Result<U, E>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? ok(mapFn(unwrap(r))) : r) as Result<U, E>;
+  const op = (r: Result<T, E>) => (isOk(r) ? ok(mapFn(r.value)) : r) as Result<U, E>;
   return curry1(op, result);
 }
 
@@ -632,7 +678,7 @@ export function mapOr<T, U, E>(
   result?: Result<T, E>
 ): U | ((result: Result<T, E>) => U) | ((mapFn: (t: T) => U) => (result: Result<T, E>) => U) {
   function fullOp(fn: (t: T) => U, r: Result<T, E>): U {
-    return isOk(r) ? fn(unwrap(r)) : orU;
+    return isOk(r) ? fn(r.value) : orU;
   }
 
   function partialOp(fn: (t: T) => U): (maybe: Result<T, E>) => U;
@@ -704,7 +750,7 @@ export function mapOrElse<T, U, E>(
   result?: Result<T, E>
 ): U | ((result: Result<T, E>) => U) | ((mapFn: (t: T) => U) => (result: Result<T, E>) => U) {
   function fullOp(fn: (t: T) => U, r: Result<T, E>) {
-    return isOk(r) ? fn(unwrap(r)) : orElseFn(unwrapErr(r));
+    return isOk(r) ? fn(r.value) : orElseFn(r.error);
   }
 
   function partialOp(fn: (t: T) => U): (maybe: Result<T, E>) => U;
@@ -759,7 +805,7 @@ export function mapErr<T, E, F>(
   mapErrFn: (e: E) => F,
   result?: Result<T, E>
 ): Result<T, F> | ((result: Result<T, E>) => Result<T, F>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? r : err(mapErrFn(unwrapErr(r)))) as Result<T, F>;
+  const op = (r: Result<T, E>) => (isOk(r) ? r : err(mapErrFn(r.error))) as Result<T, F>;
   return curry1(op, result);
 }
 
@@ -865,7 +911,7 @@ export function andThen<T, U, E>(
   thenFn: (t: T) => Result<U, E>,
   result?: Result<T, E>
 ): Result<U, E> | ((result: Result<T, E>) => Result<U, E>) {
-  const op = (r: Result<T, E>) => (isOk(r) ? thenFn(unwrap(r)) : (r as Err<any, E>));
+  const op = (r: Result<T, E>) => (isOk(r) ? thenFn(r.value) : (r as Err<any, E>));
   return curry1(op, result);
 }
 
@@ -965,10 +1011,6 @@ export const unsafelyGet = unsafelyUnwrap;
 /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
 export const unsafeGet = unsafelyUnwrap;
 
-// For internal use; but not exported because we want to emphasize that this is
-// a bad idea via the name.
-const unwrap = unsafelyUnwrap;
-
 /**
   Get the error value out of the [`Result`](#result).
 
@@ -984,10 +1026,6 @@ export function unsafelyUnwrapErr<T, E>(result: Result<T, E>): E {
 
 /** Alias for [`unsafelyUnwrapErr`](#unsafelyunwraperr) */
 export const unsafelyGetErr = unsafelyUnwrapErr;
-
-// For internal use; but not exported because we want to emphasize that this is
-// a bad idea via the name.
-const unwrapErr = unsafelyUnwrapErr;
 
 /**
   Safely get the value out of the `Ok` variant of a [`Result`](#result).
@@ -1017,7 +1055,7 @@ export function unwrapOr<T, E>(
   defaultValue: T,
   result?: Result<T, E>
 ): T | ((result: Result<T, E>) => T) {
-  const op = (r: Result<T, E>) => (isOk(r) ? unwrap(r) : defaultValue);
+  const op = (r: Result<T, E>) => (isOk(r) ? r.value : defaultValue);
   return curry1(op, result);
 }
 
@@ -1060,7 +1098,7 @@ export function unwrapOrElse<T, E>(
   orElseFn: (error: E) => T,
   result?: Result<T, E>
 ): T | ((result: Result<T, E>) => T) {
-  const op = (r: Result<T, E>) => (isOk(r) ? unwrap(r) : orElseFn(unwrapErr(r)));
+  const op = (r: Result<T, E>) => (isOk(r) ? r.value : orElseFn(r.error));
   return curry1(op, result);
 }
 
@@ -1081,8 +1119,9 @@ export const getOrElse = unwrapOrElse;
   @param result The `Result` to convert to a `Maybe`
   @returns      `Just` the value in `result` if it is `Ok`; otherwise `Nothing`
  */
-export const toMaybe = <T, E>(result: Result<T, E>): Maybe<T> =>
-  isOk(result) ? just(unwrap(result)) : nothing();
+export function toMaybe<T>(result: Result<T, any>): Maybe<T> {
+  return isOk(result) ? just(result.value) : nothing();
+}
 
 /**
   Transform a [`Maybe`](../modules/_maybe_.html#maybe) into a [`Result`](#result).
@@ -1116,8 +1155,8 @@ export function fromMaybe<T, E>(
   where the representation of the value or error is simply the value or error's
   own `toString` representation. For example:
 
-  call                              | output
-  ----------------------------------|------------------------
+                call                |         output
+  --------------------------------- | ----------------------
   `toString(ok(42))`                | `Ok(42)`
   `toString(ok([1, 2, 3]))`         | `Ok(1,2,3)`
   `toString(ok({ an: 'object' }))`  | `Ok([object Object])`n
@@ -1131,8 +1170,8 @@ export function fromMaybe<T, E>(
   @returns     The string representation of the `Maybe`.
  */
 export const toString = <T, E>(result: Result<T, E>): string => {
-  const body = (isOk(result) ? unwrap(result) : unwrapErr(result)).toString();
-  return `${result.variant}(${body})`;
+  const body = (isOk(result) ? result.value : result.error).toString();
+  return `${result.variant.toString()}(${body})`;
 };
 
 /** A lightweight object defining how to handle each variant of a Maybe. */
@@ -1453,809 +1492,39 @@ export function isInstance<T = any, E = any>(item: any): item is Result<T, E> {
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 export const Result = {
-  /**
-    Discriminant for `Ok` and `Err` variants of `Result` type.
-
-    You can use the discriminant via the `variant` property of `Result` instances
-    if you need to match explicitly on it.
-  */
   Variant,
-  /**
-    An `Ok` instance is the *successful* variant instance of the
-    [`Result`](../modules/_result_.html#result) type, representing a successful
-    outcome from an operation which may fail. For a full discussion, see [the
-    module docs](../modules/_result_.html).
-
-    @typeparam T The type wrapped in this `Ok` variant of `Result`.
-    @typeparam E The type which would be wrapped in an `Err` variant of `Result`.
-   */
   Ok,
-  /**
-    An `Err` instance is the *failure* variant instance of the
-    [`Result`](../modules/_result_.html#result) type, representing a failure
-    outcome from an operation which may fail. For a full discussion, see [the
-    module docs](../modules/_result_.html).
-
-    @typeparam T The type which would be wrapped in an `Ok` variant of `Result`.
-    @typeparam E The type wrapped in this `Err` variant of `Result`.
-  */
   Err,
-  /**
-    Is this `Result` an `Ok` instance?
-
-    In TypeScript, narrows the type from `Result<T, E>` to `Ok<T, E>`.
-  */
   isOk,
-  /**
-    Is this `Result` an `Err` instance?
-
-    In TypeScript, narrows the type from `Result<T, E>` to `Err<T, E>`.
-  */
   isErr,
-  /**
-    Create an instance of `Result.Ok`.
-
-    If you need to create an instance with a specific type (as you do whenever you
-    are not constructing immediately for a function return or as an argument to a
-    function), you can use a type parameter:
-
-    ```ts
-    const yayNumber = Result.ok<number, string>(12);
-    ```
-
-    Note: `null` is allowed by the type signature so that so that the function
-    may be used to  `throw` on passing `null` rather than constructing a type like
-    `Result<null, string>`. `undefined` is allowed as a convenience method for
-    constructing a `Result<Unit, E>`.
-
-    ```ts
-    const normalResult = Result.ok<number, string>(42);
-    const explicitUnit = Result.ok<Unit, string>(Unit);
-    const implicitUnit = Result.ok<Unit, string>();
-    ```
-
-    In the context of an immediate function return, or an arrow function with a
-    single expression value, you do not have to specify the types, so this can be
-    quite convenient.
-
-    ```ts
-    type SomeData = {
-      //...
-    };
-
-    const isValid = (data: SomeData): boolean => {
-      // true or false...
-    }
-
-    const arrowValidate = (data: SomeData): Result<Unit, string> =>
-      isValid(data) ? Result.ok() : Result.err('something was wrong!');
-
-    function fnValidate(data: someData): Result<Unit, string> {
-      return isValid(data) ? Result.ok() : Result.err('something was wrong');
-    }
-    ```
-
-    @typeparam T The type of the item contained in the `Result`.
-    @param value The value to wrap in a `Result.Ok`.
-    @throws      If you pass `null` or `undefined`.
-  */
   ok,
-  /**
-    Create an instance of `Result.Error`.
-
-    If you need to create an instance with a specific type (as you do whenever you
-    are not constructing immediately for a function return or as an argument to a
-    function), you can use a type parameter:
-
-    ```ts
-    const notString = Result.err<number, string>('something went wrong');
-    ```
-
-    Note: `null` is allowed by the type signature so that so that the function
-    may be used to  `throw` on passing `null` rather than constructing a type like
-    `Result<null, string>`. `undefined` is allowed as a convenience method for
-    constructing a `Result<Unit, E>`.
-
-    ```ts
-    const normalResult = Result.err<number, string>('oh no');
-    const explicitUnit = Result.err<number, Unit>(Unit);
-    const implicitUnit = Result.err<number, Unit>();
-    ```
-
-    In the context of an immediate function return, or an arrow function with a
-    single expression value, you do not have to specify the types, so this can be
-    quite convenient.
-
-    ```ts
-    type SomeData = {
-      //...
-    };
-
-    const isValid = (data: SomeData): boolean => {
-      // true or false...
-    }
-
-    const arrowValidate = (data: SomeData): Result<number, Unit> =>
-      isValid(data) ? Result.ok(42) : Result.err();
-
-    function fnValidate(data: someData): Result<number, Unit> {
-      return isValid(data) ? Result.ok(42) : Result.err();
-    }
-    ```
-
-    @typeparam T The type of the item contained in the `Result`.
-  */
   err,
-  /**
-    Map over a `Result` instance: apply the function to the wrapped value if the
-    instance is `Ok`, and return the wrapped error value wrapped as a new `Err` of
-    the correct type (`Result<U, E>`) if the instance is `Err`.
-
-    `Result.map` works a lot like `Array.prototype.map`, but with one important
-    difference. Both `Result` and `Array` are containers for other kinds of items,
-    but where `Array.prototype.map` has 0 to _n_ items, a `Result` always has
-    exactly one item, which is *either* a success or an error instance.
-
-    Where `Array.prototype.map` will apply the mapping function to every item in
-    the array (if there are any), `Result.map` will only apply the mapping
-    function to the (single) element if an `Ok` instance, if there is one.
-
-    If you have no items in an array of
-    numbers named `foo` and call `foo.map(x => x + 1)`, you'll still some have an
-    array with nothing in it. But if you have any items in the array (`[2, 3]`),
-    and you call `foo.map(x => x + 1)` on it, you'll get a new array with each of
-    those items inside the array "container" transformed (`[3, 4]`).
-
-    With `Result.map`, the `Err` variant is treated *by the `map` function* kind
-    of the same way as the empty array case: it's just ignored, and you get back a
-    new `Result` that is still just the same `Err` instance. But if you have an
-    `Ok` variant, the map function is applied to it, and you get back a new
-    `Result` with the value transformed, and still wrapped in an `Ok`.
-
-    #### Examples
-
-    ```ts
-    import { ok, err, map, toString } from 'true-myth/result';
-    const double = n => n * 2;
-
-    const anOk = ok(12);
-    const mappedOk = map(double, anOk);
-    console.log(toString(mappedOk)); // Ok(24)
-
-    const anErr = err("nothing here!");
-    const mappedErr = map(double, anErr);
-    console.log(toString(mappedOk)); // Err(nothing here!)
-    ```
-
-    @typeparam T  The type of the value wrapped in an `Ok` instance, and taken as
-                  the argument to the `mapFn`.
-    @typeparam U  The type of the value wrapped in the new `Ok` instance after
-                  applying `mapFn`, that is, the type returned by `mapFn`.
-    @typeparam E  The type of the value wrapped in an `Err` instance.
-    @param mapFn  The function to apply the value to if `result` is `Ok`.
-    @param result The `Result` instance to map over.
-    @returns      A new `Result` with the result of applying `mapFn` to the value
-                  in an `Ok`, or else the original `Err` value wrapped in the new
-                  instance.
-  */
   map,
-  /**
-    Map over a `Result` instance as in [`map`](#map) and get out the value
-    if `result` is an `Ok`, or return a default value if `result` is an `Err`.
-
-    #### Examples
-
-    ```ts
-    import { ok, err, mapOr } from 'true-myth/result';
-
-    const length = (s: string) => s.length;
-
-    const anOkString = ok('a string');
-    const theStringLength = mapOr(0, anOkString);
-    console.log(theStringLength);  // 8
-
-    const anErr = err('uh oh');
-    const anErrMapped = mapOr(0, anErr);
-    console.log(anErrMapped);  // 0
-    ```
-
-    @param orU The default value to use if `result` is an `Err`.
-    @param mapFn The function to apply the value to if `result` is an `Ok`.
-    @param result The `Result` instance to map over.
-  */
   mapOr,
-  /**
-    Map over a `Result` instance as in [`map`](#map) and get out the value if
-    `result` is `Ok`, or apply a function (`orElseFn`) to the value wrapped in
-    the `Err` to get a default value.
-
-    Like [`mapOr`](#mapor) but using a function to transform the error into a
-    usable value instead of simply using a default value.
-
-    #### Examples
-
-    ```ts
-    import { ok, err, mapOrElse } from 'true-myth/result';
-
-    const summarize = (s: string) => `The response was: '${s}'`;
-    const getReason = (err: { code: number, reason: string }) => err.reason;
-
-    const okResponse = ok("Things are grand here.");
-    const mappedOkAndUnwrapped = mapOrElse(getReason, summarize, okResponse);
-    console.log(mappedOkAndUnwrapped);  // The response was: 'Things are grand here.'
-
-    const errResponse = err({ code: 500, reason: 'Nothing at this endpoint!' });
-    const mappedErrAndUnwrapped = mapOrElse(getReason, summarize, errResponse);
-    console.log(mappedErrAndUnwrapped);  // Nothing at this endpoint!
-    ```
-
-    @typeparam T    The type of the wrapped `Ok` value.
-    @typeparam U    The type of the resulting value from applying `mapFn` to the
-                    `Ok` value or `orElseFn` to the `Err` value.
-    @typeparam E    The type of the wrapped `Err` value.
-    @param orElseFn The function to apply to the wrapped `Err` value to get a
-                    usable value if `result` is an `Err`.
-    @param mapFn    The function to apply to the wrapped `Ok` value if `result` is
-                    an `Ok`.
-    @param result   The `Result` instance to map over.
-  */
   mapOrElse,
-  /**
-    Map over a `Result`, exactly as in [`map`](#map), but operating on the value
-    wrapped in an `Err` instead of the value wrapped in the `Ok`. This is handy
-    for when you need to line up a bunch of different types of errors, or if you
-    need an error of one shape to be in a different shape to use somewhere else in
-    your codebase.
-
-    #### Examples
-
-    ```ts
-    import { ok, err, mapErr, toString } from 'true-myth/result';
-
-    const reason = (err: { code: number, reason: string }) => err.reason;
-
-    const anOk = ok(12);
-    const mappedOk = mapErr(reason, anOk);
-    console.log(toString(mappedOk));  // Ok(12)
-
-    const anErr = err({ code: 101, reason: 'bad file' });
-    const mappedErr = mapErr(reason, anErr);
-    console.log(toString(mappedErr));  // Err(bad file)
-    ```
-
-    @typeparam T    The type of the value wrapped in the `Ok` of the `Result`.
-    @typeparam E    The type of the value wrapped in the `Err` of the `Result`.
-    @typeparam F    The type of the value wrapped in the `Err` of a new `Result`,
-                    returned by the `mapErrFn`.
-    @param mapErrFn The function to apply to the value wrapped in `Err` if `result` is an `Err`.
-    @param result   The `Result` instance to map over an error case for.
-  */
   mapErr,
-  /**
-    You can think of this like a short-circuiting logical "and" operation on a
-    `Result` type. If `result` is `Ok`, then the result is the `andResult`. If
-    `result` is `Err`, the result is the `Err`.
-
-    This is useful when you have another `Result` value you want to provide if
-    and *only if* you have an `Ok` – that is, when you need to make sure that if you
-    `Err`, whatever else you're handing a `Result` to *also* gets that `Err`.
-
-    Notice that, unlike in [`map`](#map) or its variants, the original `result` is
-    not involved in constructing the new `Result`.
-
-    #### Examples
-
-    ```ts
-    import { and, ok, err, toString } from 'true-myth/result';
-
-    const okA = ok('A');
-    const okB = ok('B');
-    const anErr = err({ so: 'bad' });
-
-    console.log(toString(and(okB, okA)));  // Ok(B)
-    console.log(toString(and(okB, anErr)));  // Err([object Object])
-    console.log(toString(and(anErr, okA)));  // Err([object Object])
-    console.log(toString(and(anErr, anErr)));  // Err([object Object])
-    ```
-
-    @typeparam T     The type of the value wrapped in the `Ok` of the `Result`.
-    @typeparam U     The type of the value wrapped in the `Ok` of the `andResult`,
-                    i.e. the success type of the `Result` present if the checked
-                    `Result` is `Ok`.
-    @typeparam E     The type of the value wrapped in the `Err` of the `Result`.
-    @param andResult The `Result` instance to return if `result` is `Err`.
-    @param result    The `Result` instance to check.
-  */
   and,
-  /**
-    Apply a function to the wrapped value if `Ok` and return a new `Ok`
-    containing the resulting value; or if it is `Err` return it unmodified.
-
-    This differs from `map` in that `thenFn` returns another `Result`. You can use
-    `andThen` to combine two functions which *both* create a `Result` from an
-    unwrapped type.
-
-    You may find the `.then` method on an ES6 `Promise` helpful for comparison: if
-    you have a `Promise`, you can pass its `then` method a callback which
-    returns another `Promise`, and the result will not be a *nested* promise, but
-    a single `Promise`. The difference is that `Promise#then` unwraps *all*
-    layers to only ever return a single `Promise` value, whereas `Result.andThen`
-    will not unwrap nested `Result`s.
-
-    This is also commonly known as (and therefore aliased as) [`flatMap`] or
-    [`chain`]. It is sometimes also known as `bind`, but *not* aliased as such
-    because [`bind` already means something in JavaScript][bind].
-
-    [`flatMap`]: #flatmap
-    [`chain`]: #chain
-    [bind]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind
-
-    #### Examples
-
-    ```ts
-    import { ok, err, andThen, toString } from 'true-myth/result';
-
-    const toLengthAsResult = (s: string) => ok(s.length);
-
-    const anOk = ok('just a string');
-    const lengthAsResult = andThen(toLengthAsResult, anOk);
-    console.log(toString(lengthAsResult));  // Ok(13)
-
-    const anErr = err(['srsly', 'whatever']);
-    const notLengthAsResult = andThen(toLengthAsResult, anErr);
-    console.log(toString(notLengthAsResult));  // Err(srsly,whatever)
-    ```
-
-    @typeparam T   The type of the value wrapped in the `Ok` of the `Result`.
-    @typeparam U   The type of the value wrapped in the `Ok` of the `Result`
-                  returned by the `thenFn`.
-    @typeparam E   The type of the value wrapped in the `Err` of the `Result`.
-    @param thenFn  The function to apply to the wrapped `T` if `maybe` is `Just`.
-    @param result  The `Maybe` to evaluate and possibly apply a function to.
-  */
   andThen,
-  /** Alias for [`andThen`](#andthen). */
   chain,
-  /** Alias for [`andThen`](#andthen). */
   flatMap,
-  /**
-    Provide a fallback for a given `Result`. Behaves like a logical `or`: if the
-    `result` value is an `Ok`, returns that `result`; otherwise, returns the
-    `defaultResult` value.
-
-    This is useful when you want to make sure that something which takes a
-    `Result` always ends up getting an `Ok` variant, by supplying a default value
-    for the case that you currently have an `Err`.
-
-    ```ts
-    import { ok, err, Result, or } from 'true-utils/result';
-
-    const okA = ok<string, string>('a');
-    const okB = ok<string, string>('b');
-    const anErr = err<string, string>(':wat:');
-    const anotherErr = err<string, string>(':headdesk:');
-
-    console.log(or(okB, okA).toString());  // Ok(A)
-    console.log(or(anErr, okA).toString());  // Ok(A)
-    console.log(or(okB, anErr).toString());  // Ok(B)
-    console.log(or(anotherErr, anErr).toString());  // Err(:headdesk:)
-    ```
-
-    @typeparam T          The type wrapped in the `Ok` case of `result`.
-    @typeparam E          The type wrapped in the `Err` case of `result`.
-    @typeparam F          The type wrapped in the `Err` case of `defaultResult`.
-    @param defaultResult  The `Result` to use if `result` is an `Err`.
-    @param result         The `Result` instance to check.
-    @returns              `result` if it is an `Ok`, otherwise `defaultResult`.
-  */
   or,
-  /**
-    Like `or`, but using a function to construct the alternative `Result`.
-
-    Sometimes you need to perform an operation using other data in the environment
-    to construct the fallback value. In these situations, you can pass a function
-    (which may be a closure) as the `elseFn` to generate the fallback `Result<T>`.
-    It can then transform the data in the `Err` to something usable as an `Ok`, or
-    generate a new `Err` instance as appropriate.
-
-    Useful for transforming failures to usable data.
-
-    @param elseFn The function to apply to the contents of the `Err` if `result`
-                  is an `Err`, to create a new `Result`.
-    @param result The `Result` to use if it is an `Ok`.
-    @returns      The `result` if it is `Ok`, or the `Result` returned by `elseFn`
-                  if `result` is an `Err.
-  */
   orElse,
-  /**
-    Get the value out of the `Result`.
-
-    Returns the content of an `Ok`, but **throws if the `Result` is `Err`.**
-    Prefer to use [`unwrapOr`](#unwrapor) or [`unwrapOrElse`](#unwraporelse).
-
-    @throws If the `Result` instance is `Nothing`.
-  */
   unsafelyUnwrap,
-  /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
   unsafelyGet,
-  /** Alias for [`unsafelyUnwrap`](#unsafelyunwrap) */
   unsafeGet,
-  /**
-    Get the error value out of the [`Result`](#result).
-
-    Returns the content of an `Err`, but **throws if the `Result` is `Ok`**.
-    Prefer to use [`unwrapOrElse`](#unwraporelse).
-
-    @param result
-    @throws Error If the `Result` instance is `Nothing`.
-  */
   unsafelyUnwrapErr,
-  /** Alias for [`unsafelyUnwrapErr`](#unsafelyunwraperr) */
   unsafelyGetErr,
-  /**
-    Safely get the value out of the `Ok` variant of a [`Result`](#result).
-
-    This is the recommended way to get a value out of a `Result` most of the time.
-
-    ```ts
-    import { ok, err, unwrapOr } from 'true-myth/result';
-
-    const anOk = ok<number, string>(12);
-    console.log(unwrapOr(0, anOk));  // 12
-
-    const anErr = err<number, string>('nooooo');
-    console.log(unwrapOr(0, anErr));  // 0
-    ```
-
-    @typeparam T        The value wrapped in the `Ok`.
-    @typeparam E        The value wrapped in the `Err`.
-    @param defaultValue The value to use if `result` is an `Err`.
-    @param result       The `Result` instance to unwrap if it is an `Ok`.
-    @returns            The content of `result` if it is an `Ok`, otherwise
-                        `defaultValue`.
-  */
   unwrapOr,
-  /** Alias for [`unwrapOr`](#unwrapor) */
   getOr,
-  /**
-    Safely get the value out of a [`Result`](#result) by returning the wrapped
-    value if it is `Ok`, or by applying `orElseFn` to the value in the `Err`.
-
-    This is useful when you need to *generate* a value (e.g. by using current
-    values in the environment – whether preloaded or by local closure) instead of
-    having a single default value available (as in [`unwrapOr`](#unwrapor)).
-
-    ```ts
-    import { ok, err, unwrapOrElse } from 'true-myth/result';
-
-    // You can imagine that someOtherValue might be dynamic.
-    const someOtherValue = 2;
-    const handleErr = (errValue: string) => errValue.length + someOtherValue;
-
-    const anOk = ok<number, string>(42);
-    console.log(unwrapOrElse(handleErr, anOk));  // 42
-
-    const anErr = err<number, string>('oh teh noes');
-    console.log(unwrapOrElse(handleErr, anErr));  // 13
-    ```
-
-    @typeparam T    The value wrapped in the `Ok`.
-    @typeparam E    The value wrapped in the `Err`.
-    @param orElseFn A function applied to the value wrapped in `result` if it is
-                    an `Err`, to generate the final value.
-    @param result   The `result` to unwrap if it is an `Ok`.
-    @returns        The value wrapped in `result` if it is `Ok` or the value
-                    returned by `orElseFn` applied to the value in `Err`.
-  */
   unwrapOrElse,
-  /** Alias for [`unwrapOrElse`](#unwraporelse) */
   getOrElse,
-  /**
-    Convert a [`Result`](#result) to a [`Maybe`](../modules/_maybe_.html#maybe).
-
-    The converted type will be [`Just`] if the `Result` is [`Ok`] or [`Nothing`]
-    if the `Result` is [`Err`]; the wrapped error value will be discarded.
-
-    [`Just`]: ../classes/_maybe_.just.html
-    [`Nothing`]: ../classes/_maybe_.nothing.html
-    [`Ok`]: ../classes/_result_.ok.html
-    [`Err`]: ../classes/_result_.err.html
-
-    @param result The `Result` to convert to a `Maybe`
-    @returns      `Just` the value in `result` if it is `Ok`; otherwise `Nothing`
-  */
   toMaybe,
-  /**
-    Transform a [`Maybe`](../modules/_maybe_.html#maybe) into a [`Result`](#result).
-
-    If the `Maybe` is a [`Just`], its value will be wrapped in the [`Ok`] variant;
-    if it is a [`Nothing`] the `errValue` will be wrapped in the [`Err`] variant.
-
-    [`Just`]: ../classes/_maybe_.just.html
-    [`Nothing`]: ../classes/_maybe_.nothing.html
-    [`Ok`]: ../classes/_result_.ok.html
-    [`Err`]: ../classes/_result_.err.html
-
-    @param errValue A value to wrap in an `Err` if `maybe` is a `Nothing`.
-    @param maybe    The `Maybe` to convert to a `Result`.
-  */
   fromMaybe,
-  /**
-    Create a `String` representation of a `result` instance.
-
-    An `Ok` instance will be printed as `Ok(<representation of the value>)`, and
-    an `Err` instance will be printed as `Err(<representation of the error>)`,
-    where the representation of the value or error is simply the value or error's
-    own `toString` representation. For example:
-
-    call                              | output
-    ----------------------------------|------------------------
-    `toString(ok(42))`                | `Ok(42)`
-    `toString(ok([1, 2, 3]))`         | `Ok(1,2,3)`
-    `toString(ok({ an: 'object' }))`  | `Ok([object Object])`n
-    `toString(err(42))`               | `Err(42)`
-    `toString(err([1, 2, 3]))`        | `Err(1,2,3)`
-    `toString(err({ an: 'object' }))` | `Err([object Object])`
-
-    @typeparam T The type of the wrapped value; its own `.toString` will be used
-                to print the interior contents of the `Just` variant.
-    @param maybe The value to convert to a string.
-    @returns     The string representation of the `Maybe`.
-  */
   toString,
-  /**
-    Performs the same basic functionality as `getOrElse`, but instead of simply
-    unwrapping the value if it is `Ok` and applying a value to generate the same
-    default type if it is `Nothing`, lets you supply functions which may transform
-    the wrapped type if it is `Ok` or get a default value for `Nothing`.
-
-    This is kind of like a poor man's version of pattern matching, which
-    JavaScript currently lacks.
-
-    Instead of code like this:
-
-    ```ts
-    import { Result, isOk, match } from 'true-myth/result';
-
-    const logValue = (mightBeANumber: Result<number, string>) => {
-      console.log(
-        isOk(mightBeANumber)
-          ? unsafelyUnwrap(mightBeANumber).toString()
-          : `There was an error: ${unsafelyGetErr(mightBeANumber)}`
-      );
-    };
-    ```
-
-    ...we can write code like this:
-
-    ```ts
-    import { Result, match } from 'true-myth/result';
-
-    const logValue = (mightBeANumber: Result<number, string>) => {
-      const value = match(
-        {
-          Ok: n => n.toString(),
-          Err: e => `There was an error: ${e}`,
-        },
-        mightBeANumber
-      );
-      console.log(value);
-    };
-    ```
-
-    This is slightly longer to write, but clearer: the more complex the resulting
-    expression, the hairer it is to understand the ternary. Thus, this is
-    especially convenient for times when there is a complex result, e.g. when
-    rendering part of a React component inline in JSX/TSX.
-
-    @param matcher A lightweight object defining what to do in the case of each
-                  variant.
-    @param maybe   The `maybe` instance to check.
-  */
   match,
-  /** Alias for [`match`](#match) */
   cata,
-  /**
-    Allows quick triple-equal equality check between the values inside two `result`s
-    without having to unwrap them first.
-
-    ```ts
-    const a = Result.of(3)
-    const b = Result.of(3)
-    const c = Result.of(null)
-    const d = Result.nothing()
-
-    Result.equals(a, b) // true
-    Result.equals(a, c) // false
-    Result.equals(c, d) // true
-    ```
-
-    @param resultB A `maybe` to compare to.
-    @param resultA A `maybe` instance to check.
-  */
   equals,
-  /**
-    Allows you to *apply* (thus `ap`) a value to a function without having to
-    take either out of the context of their `Result`s. This does mean that the
-    transforming function is itself within a `Result`, which can be hard to grok
-    at first but lets you do some very elegant things. For example, `ap` allows
-    you to do this:
-
-    ```ts
-    import Result from 'true-myth/result';
-
-    const one = Result.ok<number, string>(1);
-    const five = Result.ok<number, string>(5);
-    const whoops = Result.err<number, string>('oh no');
-
-    const add = (a: number) => (b: number) => a + b;
-    const resultAdd = Result.ok<typeof add, string>(add);
-
-    resultAdd.ap(one).ap(five); // Ok(6)
-    resultAdd.ap(one).ap(whoops); // Err('oh no')
-    resultAdd.ap(whoops).ap(five) // Err('oh no')
-    ```
-
-    Without `Result.ap`, you'd need to do something like a nested `Result.match`:
-
-    ```ts
-    import { ok, err } from 'true-myth/result';
-
-    const one = ok<number, string>(1);
-    const five = ok<number, string>(5);
-    const whoops = err<number, string>('oh no');
-
-    one.match({
-      Ok: n => five.match({
-        Ok: o => ok<number, string>(n + o),
-        Err: e => err<number, string>(e),
-      }),
-      Err: e  => err<number, string>(e),
-    }); // Ok(6)
-
-    one.match({
-      Ok: n => whoops.match({
-        Ok: o => ok<number, string>(n + o),
-        Err: e => err<number, string>(e),
-      }),
-      Err: e  => err<number, string>(e),
-    }); // Err('oh no')
-
-    whoops.match({
-      Ok: n => five.match({
-        Ok: o => ok(n + o),
-        Err: e => err(e),
-      }),
-      Err: e  => err(e),
-    }); // Err('oh no')
-    ```
-
-    And this kind of thing comes up quite often once you're using `Maybe` to
-    handle optionality throughout your application.
-
-    For another example, imagine you need to compare the equality of two
-    ImmutableJS data structures, where a `===` comparison won't work. With `ap`,
-    that's as simple as this:
-
-    ```ts
-    import { ok } from 'true-myth/result';
-    import Immutable from 'immutable';
-    import { curry } from 'lodash'
-
-    const is = curry(Immutable.is);
-
-    const x = ok(Immutable.Set.of(1, 2, 3));
-    const y = ok(Immutable.Set.of(2, 3, 4));
-
-    ok(is).ap(x).ap(y); // Ok(false)
-    ```
-
-    Without `ap`, we're back to that gnarly nested `match`:
-
-    ```ts
-    * import Result, { ok, err } from 'true-myth/result';
-    import Immutable from 'immutable';
-    import { curry } from 'lodash'
-
-    const is = curry(Immutable.is);
-
-    const x = ok(Immutable.Set.of(1, 2, 3));
-    const y = ok(Immutable.Set.of(2, 3, 4));
-
-    x.match({
-      Ok: iX => y.match({
-        Ok: iY => Result.of(Immutable.is(iX, iY)),
-        Err: (e) => ok(false),
-      })
-      Err: (e) => ok(false),
-    }); // Ok(false)
-    ```
-
-    In summary: anywhere you have two `Maybe` instances and need to perform an
-    operation that uses both of them, `ap` is your friend.
-
-    Two things to note, both regarding *currying*:
-
-    1.  All functions passed to `ap` must be curried. That is, they must be of the
-        form (for add) `(a: number) => (b: number) => a + b`, *not* the more usual
-        `(a: number, b: number) => a + b` you see in JavaScript more generally.
-
-        For convenience, you may want to look at Lodash's `_.curry` or Ramda's
-        `R.curry`, which allow you to create curried versions of functions
-        whenever you want:
-
-        ```
-        import Result from 'true-myth/result';
-        import { curry } from 'lodash';
-
-        const normalAdd = (a: number, b: number) => a + b;
-        const curriedAdd = curry(normalAdd); // (a: number) => (b: number) => a + b;
-
-        Result.of(curriedAdd).ap(Result.of(1)).ap(Result.of(5)); // Ok(6)
-        ```
-
-    2.  You will need to call `ap` as many times as there are arguments to the
-        function you're dealing with. So in the case of `add`, which has the
-        "arity" (function argument count) of 2 (`a` and `b`), you'll need to call
-        `ap` twice: once for `a`, and once for `b`. To see why, let's look at what
-        the result in each phase is:
-
-        ```ts
-        const add = (a: number) => (b: number) => a + b;
-
-        const maybeAdd = Result.of(add); // Ok((a: number) => (b: number) => a + b)
-        const maybeAdd1 = maybeAdd.ap(Result.of(1)); // Ok((b: number) => 1 + b)
-        const final = maybeAdd1.ap(Result.of(3)); // Ok(4)
-        ```
-
-        So for `toString`, which just takes a single argument, you would only need
-        to call `ap` once.
-
-        ```ts
-        const toStr = (v: { toString(): string }) => v.toString();
-        Result.of(toStr).ap(12); // Ok("12")
-        ```
-
-    One other scenario which doesn't come up *quite* as often but is conceivable
-    is where you have something that may or may not actually construct a function
-    for handling a specific `Result` scenario. In that case, you can wrap the
-    possibly-present in `ap` and then wrap the values to apply to the function to
-    in `Result` themselves.
-
-    Because `Result` often requires you to type out the full type parameterization
-    on a regular basis, it's convenient to use TypeScript's `typeof` operator to
-    write out the type of a curried function. For example, if you had a function
-    that simply merged three strings, you might write it like this:
-
-    ```ts
-    import Result from 'true-myth/result';
-    import { curry } from 'lodash';
-
-    const merge3Strs = (a: string, b: string, c: string) => string;
-    const curriedMerge = curry(merge3Strs);
-
-    const fn = Result.ok<typeof curriedMerge, string>(curriedMerge);
-    ```
-
-    The alternative is writing out the full signature long-form:
-
-    ```ts
-    const fn = Result.ok<(a: string) => (b: string) => (c: string) => string, string>(curriedMerge);
-    ```
-
-    **Aside:** `ap` is not named `apply` because of the overlap with JavaScript's
-    existing [`apply`] function – and although strictly speaking, there isn't any
-    direct overlap (`Result.apply` and `Function.prototype.apply` don't intersect
-    at all) it's useful to have a different name to avoid implying that they're
-    the same.
-
-    [`apply`]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
-
-    @param resultFn result of a function from T to U
-    @param result result of a T to apply to `fn`
-  */
   ap,
-
   isInstance,
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2943,14 +2943,6 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
-husky@^0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 iconv-lite@0.4.19, iconv-lite@~0.4.13:
   version "0.4.19"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.19.tgz#f7468f60135f5e5dad3399c0a81be9a1603a082b"
@@ -4473,10 +4465,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
 
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-
 normalize-path@^2.0.0, normalize-path@^2.0.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-2.1.1.tgz#1ab28b556e198363a8c1a6f7e6fa20137fe6aed9"
@@ -5692,10 +5680,6 @@ strip-indent@^1.0.1:
   resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-1.0.1.tgz#0c7962a6adefa7bbd4ac366460a638552ae1a0a2"
   dependencies:
     get-stdin "^4.0.1"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
 
 strip-json-comments@~2.0.1:
   version "2.0.1"


### PR DESCRIPTION
- Make `value` and `error` properties public and `readonly` instead of `private`. This lets the user get them directly rather than requiring a function call, once they have properly narrowed the type.
- To go along with them, supply static `Just.unwrap`, `Ok.unwrap`, and `Err.unwrapErr` functions which can be used in functional pipelines.
- Make `variant` a `readonly` property, and properly narrow its type on the classes so comparison with it can be used to distinguish the variants directly.

Internally: directly use `value` or `error` wherever we were previously doing the extra function call, since the method context is the most common invocation.

The net of this is that the performance should be slightly better *and* using it should be slightly more idiomatic JS in the ordinary case.