### PR TITLE
Improve `Maybe.all` and `Maybe.tuple` types and implementations.

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "shelljs": "^0.8.2",
     "ts-jest": "^23.1.4",
     "typedoc": "^0.12.0",
-    "typescript": "^3.0.3",
+    "typescript": "^3.1.1",
     "typescript-eslint-parser": "^18.0.0"
   },
   "jest": {

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1409,27 +1409,21 @@ export function last<T>(array: Array<T | null | undefined>): Maybe<T> {
 
   @param maybes The `Maybe`s to resolve to a single `Maybe`.
  */
-export function all<T extends Maybe<any>>(
-  ...maybes: T[]
-): T extends Maybe<infer U> ? Maybe<U[]> : never {
-  // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
-  //               correctly parse the types in the context of `reduce`.
-  let result: T extends Maybe<infer U> ? Maybe<U[]> : never = Maybe.just([]);
+export function all<T extends Array<Maybe<unknown>>>(...maybes: T): All<T> {
+  let result: All<T> = Maybe.just([] as Maybe<unknown>[]) as All<T>;
   maybes.forEach(maybe => {
-    // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
-    //               correctly parse the types in the context of `reduce`.
     result = result.andThen(accumulatedMaybes =>
       maybe.map(m => {
         accumulatedMaybes.push(m);
         return accumulatedMaybes;
       })
-    );
+    ) as All<T>;
   });
 
-  // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
-  //               correctly parse the types in the context of `reduce`.
   return result;
 }
+
+type All<T extends Array<Maybe<any>>> = T extends Array<Maybe<infer U>> ? Maybe<Array<U>> : never;
 
 /**
   Given a tuple of `Maybe`s, return a `Maybe` of the tuple values.
@@ -1469,6 +1463,7 @@ export function all<T extends Maybe<any>>(
   @param maybes: the tuple of `Maybe`s to convert to a `Maybe` of tuple values.
  */
 // @ts-ignore -- this doesn't type-check, but it is correct!
+export function tuple<T>(maybes: [Maybe<T>]): Maybe<[T]>;
 export function tuple<T, U>(maybes: [Maybe<T>, Maybe<U>]): Maybe<[T, U]>;
 export function tuple<T, U, V>(maybes: [Maybe<T>, Maybe<U>, Maybe<V>]): Maybe<[T, U, V]>;
 export function tuple<T, U, V, W>(
@@ -1477,7 +1472,7 @@ export function tuple<T, U, V, W>(
 export function tuple<T, U, V, W, X>(
   maybes: [Maybe<T>, Maybe<U>, Maybe<V>, Maybe<W>, Maybe<X>]
 ): Maybe<[T, U, V, W, X]> {
-  // @ts-ignore -- this doesn't type-check, but it is correct!
+  // @ts-ignore -- this doesn't type-check, but it works correctly.
   return all(...maybes);
 }
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -1407,17 +1407,28 @@ export function last<T>(array: Array<T | null | undefined>): Maybe<T> {
   heteregenous arrays; TS *also* fails to infer correctly for anything but
   homogeneous arrays when using that approach.
 
-  @param args The `Maybe`s to resolve to a single `Maybe`.
+  @param maybes The `Maybe`s to resolve to a single `Maybe`.
  */
 export function all<T extends Maybe<any>>(
-  ...args: T[]
+  ...maybes: T[]
 ): T extends Maybe<infer U> ? Maybe<U[]> : never {
   // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
   //               correctly parse the types in the context of `reduce`.
-  return args.reduce(
-    (result, maybe) => result.andThen(as => maybe.map(a => as.concat(a))),
-    Maybe.just([] as T[])
-  );
+  let result: T extends Maybe<infer U> ? Maybe<U[]> : never = Maybe.just([]);
+  maybes.forEach(maybe => {
+    // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
+    //               correctly parse the types in the context of `reduce`.
+    result = result.andThen(accumulatedMaybes =>
+      maybe.map(m => {
+        accumulatedMaybes.push(m);
+        return accumulatedMaybes;
+      })
+    );
+  });
+
+  // @ts-ignore -- this is indeed the correct implementation, but TS doesn't
+  //               correctly parse the types in the context of `reduce`.
+  return result;
 }
 
 /**

--- a/test/maybe.test.ts
+++ b/test/maybe.test.ts
@@ -374,18 +374,30 @@ describe('`Maybe` pure functions', () => {
     expect(Maybe.last([1, 2, 3])).toEqual(Maybe.just(3));
   });
 
-  test('`all`', () => {
-    type ExpectedOutputType = Maybe<Array<string | number>>;
+  describe('`all`', () => {
+    test('with basic types', () => {
+      type ExpectedOutputType = Maybe<Array<string | number>>;
 
-    let onlyJusts = [Maybe.just(2), Maybe.just('three')];
-    let onlyJustsAll = Maybe.all(...onlyJusts);
-    assertType<ExpectedOutputType>(onlyJustsAll);
-    expect(onlyJustsAll).toEqual(Maybe.just([2, 'three']));
+      let onlyJusts = [Maybe.just(2), Maybe.just('three')];
+      let onlyJustsAll = Maybe.all(...onlyJusts);
+      assertType<ExpectedOutputType>(onlyJustsAll);
+      expect(onlyJustsAll).toEqual(Maybe.just([2, 'three']));
+  
+      let hasNothing = [Maybe.just(2), Maybe.nothing<string>()];
+      let hasNothingAll = Maybe.all(...hasNothing);
+      assertType<ExpectedOutputType>(hasNothingAll);
+      expect(hasNothingAll).toEqual(Maybe.nothing());
+    });
 
-    let hasNothing = [Maybe.just(2), Maybe.nothing<string>()];
-    let hasNothingAll = Maybe.all(...hasNothing);
-    assertType<ExpectedOutputType>(hasNothingAll);
-    expect(hasNothingAll).toEqual(Maybe.nothing());
+    test('with arrays', () => {
+      type ExpectedOutputType = Maybe<Array<number | string[]>>;
+
+      let nestedArrays = [Maybe.just(1), Maybe.just(['two', 'three'])];
+      let nestedArraysAll = Maybe.all(...nestedArrays);
+
+      assertType<ExpectedOutputType>(nestedArraysAll);
+      expect(nestedArraysAll).toEqual(Maybe.just([1, ['two', 'three']]));
+    });
   });
 
   test('`tuple`', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3979,13 +3979,17 @@ typescript-eslint-parser@^18.0.0:
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-typescript@3.0.x, typescript@^3.0.3:
+typescript@3.0.x:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.3.tgz#4853b3e275ecdaa27f78fda46dc273a7eb7fc1c8"
 
 typescript@^2.5.1:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.8.3.tgz#5d817f9b6f31bb871835f4edf0089f21abe6c170"
+
+typescript@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.1.1.tgz#3362ba9dd1e482ebb2355b02dfe8bcd19a2c7c96"
 
 uglify-js@^2.6:
   version "2.8.29"


### PR DESCRIPTION
- Updated the implementation of `Maybe.all` (and therefore `Maybe.tuple`, which calls it) to use `Array.prototype.push` internally to fix a bug with passing array types. See 57c48b0 for details.
- With TS 3.1, some of the bugs in the previous implementation were fixed; additionally, I figured out how to get the type signature more correct for `Maybe.all` in particular, which let me eliminate the use of `any` and `@ts-ignore` entirely in favor of `unknown` and some much safe type-casting internal to the function. As a result, I'm much more confident that the types are *correct*.